### PR TITLE
Fix `window.opener` vulnerability

### DIFF
--- a/application/helpers/oembed_helper.php
+++ b/application/helpers/oembed_helper.php
@@ -38,28 +38,28 @@ function oembed($url, $key) {
         }
         // Individual photo
         else {
-          return '<a href="'.$url.'" target="_blank"><img src="'.$response['url'].'" width="'.$response['width'].'" height="'.$response['height'].'" /></a>';
+          return '<a href="'.$url.'" target="_blank" rel="noopener noreferrer"><img src="'.$response['url'].'" width="'.$response['width'].'" height="'.$response['height'].'" /></a>';
         }
       break;
 
       case 'Dribbble':
-        return  '<a href="'.$url.'" target="_blank"><img src="'.$response['url'].'" width="'.$response['width'].'" height="'.$response['height'].'" /></a>';
+        return  '<a href="'.$url.'" target="_blank" rel="noopener noreferrer"><img src="'.$response['url'].'" width="'.$response['width'].'" height="'.$response['height'].'" /></a>';
       break;
 
       case 'Instagram':
-        return  '<a href="'.$url.'" target="_blank"><img src="'.$response['url'].'" width="'.$response['width'].'" height="'.$response['height'].'" /></a>';
+        return  '<a href="'.$url.'" target="_blank" rel="noopener noreferrer"><img src="'.$response['url'].'" width="'.$response['width'].'" height="'.$response['height'].'" /></a>';
       break;
 
       case 'Twitpic':
-        return  '<a href="'.$url.'" target="_blank"><img src="'.$response['url'].'" width="'.$response['width'].'" height="'.$response['height'].'" /></a>';
+        return  '<a href="'.$url.'" target="_blank" rel="noopener noreferrer"><img src="'.$response['url'].'" width="'.$response['width'].'" height="'.$response['height'].'" /></a>';
       break;
 
       case 'skitch':
-        return  '<a href="'.$url.'" target="_blank"><img src="'.$response['url'].'" width="'.$response['width'].'" height="'.$response['height'].'" /></a>';
+        return  '<a href="'.$url.'" target="_blank" rel="noopener noreferrer"><img src="'.$response['url'].'" width="'.$response['width'].'" height="'.$response['height'].'" /></a>';
       break;
 
       case 'YouTube' :
-        return $response['html'] . '<div class="videoInfo"><span class="viLeft">by <a target="_blank" href="'.$response['author_url'].'">'.$response['author_name'].'</a></span><p>'.$response['description'].'</p></div>';
+        return $response['html'] . '<div class="videoInfo"><span class="viLeft">by <a target="_blank" rel="noopener noreferrer" href="'.$response['author_url'].'">'.$response['author_name'].'</a></span><p>'.$response['description'].'</p></div>';
       break;
 
       // Vimeo, other video sites and generic HTML

--- a/application/language/locales/pl_PL/LC_MESSAGES/unmark.po
+++ b/application/language/locales/pl_PL/LC_MESSAGES/unmark.po
@@ -595,10 +595,10 @@ msgstr "Dziękujemy za wypróbowanie Unmark. Mamy nadzieję, że "
 
 #: application/views/layouts/sidebar/sidebar_notices.php:11
 msgid ""
-"For usage tips <a target=\"_blank\" href=\"https://twitter.com/unmarkit"
+"For usage tips <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://twitter.com/unmarkit"
 "\">follow us on Twitter</a>! Please tell your friends about Unmark."
 msgstr ""
-"Aby uzyskać więcej wskazówek <a href=\"https://twitter.com/unmarkit\">śledź "
+"Aby uzyskać więcej wskazówek <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://twitter.com/unmarkit\">śledź "
 "nas na Twitterze</a>! Nie zapomnij powiedzieć swoim znajomym o Unmark."
 
 #: application/views/layouts/timeline.php:8
@@ -1042,10 +1042,10 @@ msgstr ""
 #: custom/views/marks/upgrade_notice.php:46
 #, php-format
 msgid ""
-"Please check out our <a href=\"%s\" target=\"_blank\">FAQ</a> for more "
+"Please check out our <a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\">FAQ</a> for more "
 "information."
 msgstr ""
-"Sprawdź nasz <a href=\"%s\" target=\"_blank\">FAQ</a> aby uzyskać więcej "
+"Sprawdź nasz <a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\">FAQ</a> aby uzyskać więcej "
 "informacji."
 
 #: custom/views/welcome.php:42

--- a/application/views/layouts/navigation/nav_panels.php
+++ b/application/views/layouts/navigation/nav_panels.php
@@ -31,15 +31,15 @@
 
 	<h4 class="nav-heading"><?php echo _('Help')?></h4>
 	<ul class="nav-list">
-		<li><a target="_blank" href="http://help.unmark.it/" title="Unmark Help"><?php echo _('Unmark Help') ?></a></li>
-		<li><a target="_blank" href="http://help.unmark.it/bookmarklet" title="Get the bookmarklet"><?php echo _('Bookmarklet Help') ?></a></li>
-		<li><a target="_blank" href="http://twitter.com/unmarkit" title="Follow us on Twitter">Follow us on Twitter</a></li>
-		<li><a target="_blank" href="mailto:colin+unmark@cdevroe.com" title="Contact support">Contact Support</a></li>
+		<li><a target="_blank" rel="noopener noreferrer" href="http://help.unmark.it/" title="Unmark Help"><?php echo _('Unmark Help') ?></a></li>
+		<li><a target="_blank" rel="noopener noreferrer" href="http://help.unmark.it/bookmarklet" title="Get the bookmarklet"><?php echo _('Bookmarklet Help') ?></a></li>
+		<li><a target="_blank" rel="noopener noreferrer" href="http://twitter.com/unmarkit" title="Follow us on Twitter">Follow us on Twitter</a></li>
+		<li><a target="_blank" rel="noopener noreferrer" href="mailto:colin+unmark@cdevroe.com" title="Contact support">Contact Support</a></li>
 	</ul>
 	<h4 class="nav-heading"><?php echo _('Tools')?></h4>
 	<ul class="nav-list">
 		<li><a href="javascript:(function()%7Bf%3D%27<?php print rtrim(base_url(),'/'); ?>%2Fmark/add%3Furl%3D%27%2BencodeURIComponent(window.location.href)%2B%27%26title%3D%27%2BencodeURIComponent(document.title)%2B%27%26v%3D6%26%27%3Ba%3Dfunction()%7Bif(!window.open(f%2B%27noui%3D1%26jump%3Ddoclose%27,%27nilaiv2%27,%27location%3D1,links%3D0,scrollbars%3D0,toolbar%3D0,width%3D594,height%3D485%27))location.href%3Df%2B%27jump%3Dyes%27%7D%3Bif(/Firefox/.test(navigator.userAgent))%7BsetTimeout(a,0)%7Delse%7Ba()%7D%7D)();">Save to Unmark</a></li>
-		<li><a target="_blank" href="https://chrome.google.com/webstore/detail/unmark/cdhnljlbeehjgddokagghpfgahhlifch"><?php echo _('Get the Chrome Extension') ?></a></li>
+		<li><a target="_blank" rel="noopener noreferrer" href="https://chrome.google.com/webstore/detail/unmark/cdhnljlbeehjgddokagghpfgahhlifch"><?php echo _('Get the Chrome Extension') ?></a></li>
 	</ul>
 	<p style="text-align: center;">Version <?php echo $this->config->item('unmark_version'); ?></p>
 </div>

--- a/application/views/layouts/sidebar.php
+++ b/application/views/layouts/sidebar.php
@@ -27,8 +27,8 @@
     <div class="sidebar-block">
         <div class="sidebar-inner">
             <a href="javascript:(function()%7Bl%3D%22<?php print rtrim(base_url(),'/'); ?>%2Fmark%2Fadd%3Furl%3D%22%2BencodeURIComponent(window.location.href)%2B%22%26title%3D%22%2BencodeURIComponent(document.title)%2B%22%26v%3D1%26nowindow%3Dyes%26%22%3Bvar%20e%3Dwindow.open(l%2B%22noui%3D1%22%2C%22Unmark%22%2C%22location%3D0%2Clinks%3D0%2Cscrollbars%3D0%2Ctoolbar%3D0%2Cwidth%3D594%2Cheight%3D485%22)%3B%7D)()" class="btn">Unmark+</a>
-            <li><a target="_blank" href="https://chrome.google.com/webstore/detail/unmark/cdhnljlbeehjgddokagghpfgahhlifch"><?php echo _('Get the Chrome Extension') ?></a></li>
-            <p class="clear sidenote"><a href="http://help.unmark.it/bookmarklet" target="_blank"><?php echo _('Learn more')?></a></p>
+            <li><a target="_blank" rel="noopener noreferrer" href="https://chrome.google.com/webstore/detail/unmark/cdhnljlbeehjgddokagghpfgahhlifch"><?php echo _('Get the Chrome Extension') ?></a></li>
+            <p class="clear sidenote"><a href="http://help.unmark.it/bookmarklet" target="_blank" rel="noopener noreferrer"><?php echo _('Learn more')?></a></p>
         </div>
     </div>
     <?php endif; ?>

--- a/application/views/layouts/sidebar/sidebar_notices.php
+++ b/application/views/layouts/sidebar/sidebar_notices.php
@@ -7,6 +7,6 @@
 
 <div class="sidebar-block">
     <div class="sidebar-inner">
-		<p><?php echo _('For usage tips <a target="_blank" href="https://twitter.com/unmarkit">follow us on Twitter</a>!')?></p>
+		<p><?php echo _('For usage tips <a target="_blank" rel="noopener noreferrer" href="https://twitter.com/unmarkit">follow us on Twitter</a>!')?></p>
     </div>
 </div>

--- a/application/views/marks/index.php
+++ b/application/views/marks/index.php
@@ -66,17 +66,17 @@
             <?php foreach ($marks as $mark) :
             if (isset($mark->mark_title)) $mark->title = $mark->mark_title; ?>
                 <div id="mark-<?php print $mark->mark_id; ?>" class="mark label-<?php print $mark->label_id; ?>">
-                    <h2 class="hideoutline"><a target="_blank" href="<?php print $mark->url; ?>"><?php print $mark->title; ?></a></h2>
+                    <h2 class="hideoutline"><a target="_blank" rel="noopener noreferrer" href="<?php print $mark->url; ?>"><?php print $mark->title; ?></a></h2>
                     <div class="mark-meta">
                         <span class="mark-date"><?php print $mark->nice_time; ?></span>
                         <span class="mark-sep">&bull;</span>
-                        <span class="mark-link"><a target="_blank" href="<?php print $mark->url; ?>"><?php print niceUrl($mark->url); ?></a></span>
+                        <span class="mark-link"><a target="_blank" rel="noopener noreferrer" href="<?php print $mark->url; ?>"><?php print niceUrl($mark->url); ?></a></span>
                     </div>
                     <div class="mark-actions">
                         <a title="View Mark Info" class="action mark-archive tabletonly" href="#" data-nofade="true" data-action="show_mark_info" data-mark="mark-data-<?php print $mark->mark_id; ?>">
                             <i class="icon-ellipsis"></i>
                         </a>
-                        <a target="_blank" title="Open Mark" class="mark-info" href="<?php print $mark->url; ?>" data-mark="mark-data-<?php print $mark->mark_id; ?>">
+                        <a target="_blank" rel="noopener noreferrer" title="Open Mark" class="mark-info" href="<?php print $mark->url; ?>" data-mark="mark-data-<?php print $mark->mark_id; ?>">
                             <i class="icon-goto_link"></i>
                         </a>
                         <?php if ($lookup_type == "archive") : ?>

--- a/assets/js/templates/JS-Templates.html
+++ b/assets/js/templates/JS-Templates.html
@@ -25,15 +25,15 @@
 <!-- Main Mark Listing Template -->
 
 <div id="mark-{{mark_id}}" class="mark label-{{label_id}}">
-    <h2 class="hideoutline"><a target="_blank" href="{{url}}">{{title}}</a></h2>
+    <h2 class="hideoutline"><a target="_blank" rel="noopener noreferrer" href="{{url}}">{{title}}</a></h2>
     <div class="mark-meta">
         <span class="mark-date">{{nice_time}}</span>
         <span class="mark-sep">•</span>
-        <span class="mark-link"><a target="_blank" href="{{url}}">{{prettyurl}}</a></span>
+        <span class="mark-link"><a target="_blank" rel="noopener noreferrer" href="{{url}}">{{prettyurl}}</a></span>
     </div>
     <div class="mark-actions" style="display: none;">
         <a class="action mark-archive tabletonly" href="#" data-nofade="true" data-action="show_mark_info" data-mark="mark-data-{{mark_id}}"><i class="icon-ellipsis"></i></a>
-        <a target="_blank" class="mark-info" href="{{url}}" data-mark="mark-data-{{mark_id}}"><i class="icon-goto_link"></i></a>
+        <a target="_blank" rel="noopener noreferrer" class="mark-info" href="{{url}}" data-mark="mark-data-{{mark_id}}"><i class="icon-goto_link"></i></a>
         {{#archived_on}}
             <a title="Unarchive Mark" class="action mark-archive" data-action="mark_restore" href="#" data-id="{{mark_id}}"><i class="icon-label"></i></a>
         {{/archived_on}}

--- a/assets/js/unmark.marks.js
+++ b/assets/js/unmark.marks.js
@@ -341,7 +341,7 @@
             editable_mark_title.attr('contenteditable', false).removeClass('editable');
 
             // Return Mark title back to being wrapped by URL
-            editable_mark_title.html('<a target="_blank" href="'+mark_url+'">'+editable_mark_title.text()+'</a>');
+            editable_mark_title.html('<a target="_blank" rel="noopener noreferrer" href="'+mark_url+'">'+editable_mark_title.text()+'</a>');
 
             // Taggify the notes (means also wrapping up any links within)
             unmark.tagify_notes(editable_notes);
@@ -374,7 +374,7 @@
 
         if (notetext !== '') {
             // First Linkify Notes
-            notetext = notetext.replace(/(https?:\/\/[^\]\s]+)(?: ([^\]]*))?/g, "<a target='_blank' href='$1'>$1</a>");
+            notetext = notetext.replace(/(https?:\/\/[^\]\s]+)(?: ([^\]]*))?/g, "<a target='_blank' rel='noopener noreferrer' href='$1'>$1</a>");
             // Then Tagify It
             notetext = notetext.replace(/#(\S*)/g,'<a href="/marks/tag/$1">#$1</a>');
         } else {


### PR DESCRIPTION
Previously, unmark.it allowed any site
to modify the location of the referring browser window,
allowing their site to navigate you to a new page of their choosing.

See: https://dev.to/phishing
for more info.
